### PR TITLE
improve footer alignment for mobile devices 

### DIFF
--- a/src/sections/Footer.tsx
+++ b/src/sections/Footer.tsx
@@ -44,7 +44,7 @@ export default function Footer() {
         <div className={classNames(
             " px-4 pb-16 pt-8",
             "flex flex-col",
-            "items-center"
+            "sm:items-center"
         )}>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-24 gap-y-12">
                 <FooterSection title={t("social_and_community")}>
@@ -71,7 +71,7 @@ export default function Footer() {
                       href={data.developerSite}>{data.developerName}</MyLink>
             </div>
             <div className="h-8"/>
-            <div className="flex flex-col md:flex-row justify-center items-center">
+            <div className="flex flex-col md:flex-row justify-center sm:items-center">
                 <div>
                     {t("footer_released_under")} <MyLink className="text-blue-500" href={data.licence.link}>{data.licence.name}</MyLink>
                 </div>


### PR DESCRIPTION
Align the footer section to the start of the screen for the better readability and design.

Closes Issue: #5  

Before
![image](https://github.com/user-attachments/assets/0859d0d1-85ef-425e-8bfe-c76aac92d1c3)

After
![image](https://github.com/user-attachments/assets/22d74fca-8729-4552-849c-7afc9f14329f)
