### PR TITLE
improve overall responsiveness of the home section

### DIFF
--- a/src/sections/Footer.tsx
+++ b/src/sections/Footer.tsx
@@ -12,7 +12,7 @@ function FooterItem(
     }
 ) {
     return <MyLink href={props.link} target="_blank">
-        <div className="text-base opacity-75">
+        <div className="text-sm sm:text-base opacity-75">
             {props.name}
         </div>
     </MyLink>
@@ -24,7 +24,7 @@ function FooterSection(
     }
 ) {
     return <div className="flex flex-col justify-start">
-        <div className="font-bold opacity-75 text-2xl">
+        <div className="font-bold opacity-75 text-xl sm:text-2xl">
             {props.title}
         </div>
         <div className="h-6"/>
@@ -66,12 +66,12 @@ export default function Footer() {
                 </FooterSection>
             </div>
             <div className="h-8"/>
-            <div className="text-lg font-bold">
+            <div className="text-base sm:text-lg font-bold">
                 {t("footer_developed_with_love")} <MyLink className="text-blue-500"
                       href={data.developerSite}>{data.developerName}</MyLink>
             </div>
             <div className="h-8"/>
-            <div className="flex flex-col md:flex-row justify-center sm:items-center">
+            <div className="flex flex-col md:flex-row justify-center sm:items-center text-sm sm:text-base">
                 <div>
                     {t("footer_released_under")} <MyLink className="text-blue-500" href={data.licence.link}>{data.licence.name}</MyLink>
                 </div>

--- a/src/sections/home/index.tsx
+++ b/src/sections/home/index.tsx
@@ -23,19 +23,19 @@ function Hero(props: { icon: ImageProp, title: string, description: string }) {
                     `blur-3xl bg-gradient-to-br my-primary-gradient-colors`
                 )}
             />
-            <img className="h-64 w-64 z-[1]"
+            <img className="h-52 sm:h-64 w-52 sm:w-64 z-[1]"
                  src={iconSource}
                  alt={props.icon.alt}
             />
         </div>
         <div className="flex flex-col space-y-10 p-4 md:max-w-[55%]">
             <h2 className={classNames(
-                "text-5xl md:text-6xl font-extrabold"
+                "text-4xl md:text-5xl lg:text-6xl font-extrabold text-center md:text-left"
             )}>{props.title}</h2>
             <h5 className={classNames(
-                "text-3xl font-medium leading-normal"
+                "text-xl sm:text-2xl lg:text-3xl font-medium leading-normal text-center md:text-left"
             )}>{props.description}</h5>
-            <div className="flex flex-row flex-wrap gap-4">
+            <div className="flex flex-row flex-wrap gap-4 justify-center md:justify-start">
                 <MyLink href={`/#download`}>
                     <div className={classNames(
                         "btn btn-primary btn-lg rounded-full border-2",
@@ -84,7 +84,7 @@ function SectionWithTitle(
         "space-y-8"
     )}>
         <MyLink href={`#${props.id}`}>
-            <div className="inline-block font-bold text-4xl">
+            <div className="inline-block font-bold text-3xl sm:text-4xl">
                 {props.title}
             </div>
         </MyLink>
@@ -119,11 +119,11 @@ function Feature({feature}: {
         "shadow hover:shadow-lg",
         "gradient-border"
     )}>
-        <div className="text-2xl font-bold">
+        <div className="text-xl sm:text-2xl font-bold">
             {t(feature.title)}
         </div>
         <div className="mt-2"/>
-        <div className="text-base opacity-75">
+        <div className="text-sm sm:text-base opacity-75">
             {t(feature.description)}
         </div>
     </div>


### PR DESCRIPTION
Changes:
- decrease the size of app logo on home section for mobile devices.
- improve the responsiveness of home section title and description.
- center the home section title and description for smaller devices.
- improve font responsiveness of features section and footer section.

Before
![image](https://github.com/user-attachments/assets/b45cdab6-d29a-4f7c-94cd-a09ac20c9e1a)

After
![image](https://github.com/user-attachments/assets/1e189ca5-1c6e-4d61-8e09-26a264ef406d)
