### PR TITLE
fix(footer): replace © symbol with &copy; entity for proper rendering

### DIFF
--- a/src/sections/Footer.tsx
+++ b/src/sections/Footer.tsx
@@ -77,7 +77,7 @@ export default function Footer() {
                 </div>
                 <div className="divider md:divider-horizontal"/>
                 <div dir="ltr">
-                    © {data.copyright.since}-present {data.copyright.for}
+                    &copy; {data.copyright.since}-present {data.copyright.for}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Used the HTML entity `&copy;` to ensure the copyright symbol displays
correctly across all browsers and devices.